### PR TITLE
Update README import instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Cada arquivo aborda um tema específico, facilitando o estudo segmentado ou inte
 3. Clique em **"Importar Arquivo"** e selecione o arquivo CSV desejado (ex: `redes_flashcards_comandos.csv`)
 4. Na tela de importação:
    - **Tipo de arquivo:** CSV
-   - **Separador de campo:** Vírgula (`,")
+   - **Separador de campo:** Vírgula (`,`)
    - **Codificação:** UTF-8
    - **Mapeie os campos:**
      - Campo 1 → Frente (Termo)


### PR DESCRIPTION
## Summary
- correct typographical error in README

## Testing
- `grep -n "Separador" -n README.md`

------
https://chatgpt.com/codex/tasks/task_e_68401f899b748322803479f21d0e10de